### PR TITLE
Feature/settings - Addition of test db name & dependency

### DIFF
--- a/dev_up/settings.py
+++ b/dev_up/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'drf_yasg',
     'post',
 ]
 

--- a/dev_up/settings.py
+++ b/dev_up/settings.py
@@ -87,9 +87,6 @@ DATABASES = {
         'USER': os.environ.get('POSTGRESQL_USER'),
         'PASSWORD': os.environ.get('POSTGRESQL_PASSWORD'),
         'PORT': os.environ.get('POSTGRESQL_PORT'),
-        'TEST': {
-            'NAME': os.environ.get('TEST_DB_NAME', 'test_db'),
-        },
     }
 }
 

--- a/dev_up/settings.py
+++ b/dev_up/settings.py
@@ -85,7 +85,10 @@ DATABASES = {
         'NAME': os.environ.get('POSTGRESQL_NAME'),
         'USER': os.environ.get('POSTGRESQL_USER'),
         'PASSWORD': os.environ.get('POSTGRESQL_PASSWORD'),
-        'PORT': os.environ.get('POSTGRESQL_PORT')
+        'PORT': os.environ.get('POSTGRESQL_PORT'),
+        'TEST': {
+            'NAME': os.environ.get('TEST_DB_NAME', 'test_db'),
+        },
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest-django
 djangorestframework
 psycopg2
 model_mommy
+drf-yasg==1.17.1


### PR DESCRIPTION
파이테스트를 실행 시에 DB에 접속하는 테스트가 있으면 test db를 만드는데 이 과정에서
NAME을 지정해주지 않으면 오류가 납니다.
그 부분에 대한 추가와 자동화된 API Docs를 위한 swagger 및 redoc을 지원해주는 drf-yasg를 추가했습니다.