### PR TITLE
Add --nomigrations option on setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [tool:pytest]
 python_files = tests.py test_*.py *_tests.py
-addopts = --verbose --reuse-db --create-db --nomigrations
+addopts = --verbose --nomigrations
 DJANGO_SETTINGS_MODULE = dev_up.settings
 
 [aliases]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [tool:pytest]
 python_files = tests.py test_*.py *_tests.py
-addopts = --verbose --reuse-db --create-db
+addopts = --verbose --reuse-db --create-db --nomigrations
 DJANGO_SETTINGS_MODULE = dev_up.settings
 
 [aliases]


### PR DESCRIPTION
마이그레이션을 하지 않고 pytest에서 db에 접속하여 테스트 할시 일어나는 에러를
방지하기 위한 추가입니다.