### PR TITLE
settings.py 환경변수 기본값 제거

### DIFF
--- a/dev_up/settings.py
+++ b/dev_up/settings.py
@@ -23,10 +23,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 # SECRET_KEY = '#2r0owr!p%q3k%^$wb3nt!rqh^v^dha5k!z%7=7%26nv!1&ig8'
 
-SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "abcd")
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DJANGO_MODE", "development") != "production"
+DEBUG = os.environ["DJANGO_MODE"] != "production"
 
 ALLOWED_HOSTS: List[str] = []
 
@@ -84,11 +84,11 @@ WSGI_APPLICATION = 'dev_up.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'HOST': os.environ.get('POSTGRESQL_HOST'),
-        'NAME': os.environ.get('POSTGRESQL_NAME'),
-        'USER': os.environ.get('POSTGRESQL_USER'),
-        'PASSWORD': os.environ.get('POSTGRESQL_PASSWORD'),
-        'PORT': os.environ.get('POSTGRESQL_PORT'),
+        'HOST': os.environ['POSTGRESQL_HOST'],
+        'NAME': os.environ['POSTGRESQL_NAME'],
+        'USER': os.environ['POSTGRESQL_USER'],
+        'PASSWORD': os.environ['POSTGRESQL_PASSWORD'],
+        'PORT': os.environ['POSTGRESQL_PORT'],
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ flake8
 isort
 pytest
 pytest-cov
+pytest-env
 autopep8
 mypy
 django-stubs

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,14 @@
 python_files = tests.py test_*.py *_tests.py
 addopts = --verbose --nomigrations
 DJANGO_SETTINGS_MODULE = dev_up.settings
+env =
+    DJANGO_SECRET_KEY=abcd
+    DJANGO_MODE=development
+    POSTGRESQL_HOST=
+    POSTGRESQL_NAME=
+    POSTGRESQL_USER=
+    POSTGRESQL_PASSWORD=
+    POSTGRESQL_PORT=
 
 [aliases]
 test = pytest


### PR DESCRIPTION
기존에는 `os.environ.get`으로 기본값을 설정해놨었는데,

실제 돌아가는 서비스에서 꼭 필요한 환경변수들은 꼭 설정이 되어야 하는게 맞다고 생각해서, 시작전 오류를 내는게 더 좋을 것 같다 판단합니다.

따라서 pytest를 이용한 테스트의 경우 pytest-env 패키지를 이용해 pytest 수행시에 환경변수를 설정해줄 수 있도록 수정했습니다.