### PR TITLE
Serializer를 위한 데코레이터

### DIFF
--- a/common/decorators/serializers.py
+++ b/common/decorators/serializers.py
@@ -1,5 +1,6 @@
+from collections import OrderedDict
 from datetime import datetime
-from typing import Any, Callable, cast, Type, Dict, Optional, TypeVar, Iterable, OrderedDict
+from typing import Any, Callable, Dict, Iterable, Optional, Type, TypeVar, cast
 
 from django.db import models
 from rest_framework import serializers
@@ -54,7 +55,7 @@ def filtered_serializer(super_class: type,
                           tuple([super_meta_class]),
                           {})
         declared_fields = getattr(cls, '_declared_fields')
-        new_declared_fields = OrderedDict()
+        new_declared_fields: OrderedDict[str, Any] = OrderedDict()
         for key, value in declared_fields.items():
             if key in field_set:
                 _fields.add(key)

--- a/common/decorators/serializers.py
+++ b/common/decorators/serializers.py
@@ -1,0 +1,248 @@
+from datetime import datetime
+from typing import Any, Callable, cast, Type, Dict, Optional, TypeVar, Iterable, OrderedDict
+
+from django.db import models
+from rest_framework import serializers
+
+T = TypeVar('T', bound=serializers.Field)
+U = TypeVar('U', bound=serializers.Serializer)
+V = TypeVar('V', bound=models.Model)
+
+
+def filtered_serializer(super_class: type,
+                        fields: Iterable[str],
+                        meta: Optional[Dict[str, Any]] = None,
+                        ) -> Callable[[type], Type[U]]:
+    """
+
+    Args:
+        super_class: the target serializer class to be filtered
+        fields: allowed fields ( only these fields will be added in a new serializer class )
+        meta:
+
+    Returns:
+        wrapping function returning a generated class or itself
+        Note that it regenerates a class if the given class is not a subclass of
+        `rest_framework.serializers.Serializer`
+
+    Examples:
+        >>> @serializer(test_model, {'depth': 1})
+        >>> class TestSerializer:
+        >>>     # required and db field
+        >>>     test_field = required(int, 'help text for test_field')
+        >>>     # not required and not db field
+        >>>     test_field2 = field(int, 'help text for test_field2', False)
+        >>>
+        >>> @filtered_serializer(TestSerializer, ['test_field'], {'depth': 2})
+        >>> class TestSerializer:
+        >>>     # required and db field
+        >>>     test_field2 = required(int, 'help text for test_field')
+        >>>     # not required and not db field
+        >>>     test_field3 = field(int, 'help text for test_field2', False)
+
+    """
+    assert issubclass(super_class, serializers.Serializer)
+    field_set = set(fields)
+
+    def wrap(origin: type) -> Type[U]:
+        _fields = set()
+        cls = type(f'{origin.__module__}.{origin.__name__}',
+                   tuple([super_class]),
+                   {})
+        super_meta_class = getattr(cls, 'Meta')
+        meta_class = type(f'{origin.__module__}.{origin.__name__}.Meta',
+                          tuple([super_meta_class]),
+                          {})
+        declared_fields = getattr(cls, '_declared_fields')
+        new_declared_fields = OrderedDict()
+        for key, value in declared_fields.items():
+            if key in field_set:
+                _fields.add(key)
+                new_declared_fields[key] = value
+
+        for key, value in origin.__dict__.items():
+            if isinstance(value, _Item):
+                new_declared_fields[key] = value.origin
+                if value.db_field:
+                    _fields.add(key)
+
+        setattr(cls, '_declared_fields', new_declared_fields)
+
+        setattr(meta_class, 'fields', tuple(_fields))
+        if meta is not None:
+            for key, value in meta.items():
+                setattr(meta, key, value)
+        setattr(cls, 'Meta', meta_class)
+
+        return cast(Type[U], cls)
+
+    return wrap
+
+
+def serializer(model: Type[V],
+               meta: Optional[Dict[str, Any]] = None,
+               ) -> Callable[[type], Type[U]]:
+    """
+    Args:
+        model: the target model to update
+        meta: additional fields for Meta class
+
+    Returns:
+        wrapping function returning a generated class or itself
+        Note that it regenerates a class if the given class is not a subclass of
+        `rest_framework.serializers.Serializer`
+
+    Examples:
+        >>> @serializer(test_model, {'depth': 1})
+        >>> class TestSerializer:
+        >>>     # required and db field
+        >>>     test_field = required(int, 'help text for test_field')
+        >>>     # not required and not db field
+        >>>     test_field2 = field(int, 'help text for test_field2', False)
+    """
+
+    def wrap(origin: type) -> Type[U]:
+        meta_class: Any
+        inherited = [origin]
+        if not issubclass(origin, serializers.Serializer):
+            inherited.append(serializers.Serializer)
+        if not hasattr(origin, 'Meta'):
+            meta_class = type(f'{origin.__module__}.{origin.__name__}.Meta', tuple(), {
+                'model': model
+            })
+        else:
+            meta_class = getattr(origin, 'Meta')
+            meta_class.model = model
+
+        cls = type(f'{origin.__module__}.{origin.__name__}',
+                   tuple(inherited),
+                   dict(Meta=meta_class))
+        _fields = set()
+        declared_fields = getattr(cls, '_declared_fields')
+        for key, value in origin.__dict__.items():
+            if isinstance(value, _Item):
+                declared_fields[key] = value.origin
+                if value.db_field:
+                    _fields.add(key)
+
+        meta_class.fields = tuple(_fields)
+        if meta is not None:
+            for key, value in meta.items():
+                setattr(meta_class, key, value)
+        meta_class.model = model
+
+        return cast(Type[U], cls)
+
+    return wrap
+
+
+def model_serializer(model: Type[V],
+                     meta: Optional[Dict[str, Any]] = None,
+                     fields: Optional[Iterable[str]] = None,
+                     ) -> Callable[[type], Type[U]]:
+    """
+    Args:
+        model: the target model to update
+        meta: additional fields for Meta class
+        fields: allowed fields, if it is :data:`None`, all fields are allowed.
+
+    Returns:
+        wrapping function returning a generated class or itself
+        Note that it regenerates a class if the given class is not a subclass of
+        `rest_framework.serializers.Serializer`
+
+    Examples:
+        >>> @model_serializer(test_model, {'depth': 1}, ['test_inherited_field'])
+        >>> class TestSerializer:
+        >>>     # required and db field
+        >>>     test_field = required(int, 'help text for test_field')
+        >>>     # not required and not db field
+        >>>     test_field2 = field(int, 'help text for test_field2', False)
+    """
+    filtered_fields = set(fields or [])
+
+    def wrap(origin: type) -> Type[U]:
+        meta_class: Any
+        inherited = [origin]
+        if not issubclass(origin, serializers.ModelSerializer):
+            inherited.append(serializers.ModelSerializer)
+        if not hasattr(origin, 'Meta'):
+            meta_class = type(f'{origin.__module__}.{origin.__name__}.Meta', tuple(), {
+                'model': model
+            })
+        else:
+            meta_class = getattr(origin, 'Meta')
+            meta_class.model = model
+
+        cls = type(f'{origin.__module__}.{origin.__name__}',
+                   tuple(inherited),
+                   dict(Meta=meta_class))
+        _fields = set()
+        _referenced = set()
+        declared_fields = getattr(cls, '_declared_fields')
+        for key, value in origin.__dict__.items():
+            if isinstance(value, _Item):
+                declared_fields[key] = value.origin
+                if value.db_field:
+                    _fields.add(key)
+                if value.source:
+                    _referenced.add(value.source)
+
+        for f in model._meta.get_fields():
+            if f.name not in _referenced and (fields is None or f.name in filtered_fields):
+                _fields.add(f.name)
+
+        meta_class.fields = tuple(_fields)
+        if meta is not None:
+            for key, value in meta.items():
+                setattr(meta_class, key, value)
+        meta_class.model = model
+
+        return cast(Type[U], cls)
+
+    return wrap
+
+
+class Date:
+    pass
+
+
+class DateTime:
+    pass
+
+
+class Method:
+    pass
+
+
+FIELD_DICT: Dict[type, type] = {
+    int: serializers.IntegerField,
+    str: serializers.CharField,
+    Date: serializers.DateField,
+    datetime: serializers.DateTimeField,
+    DateTime: serializers.DateTimeField,
+    Method: serializers.SerializerMethodField
+}
+
+
+class _Item:
+    def __init__(self, _db_field: bool, _origin: type, **kwargs: Any) -> None:
+        if not issubclass(_origin, serializers.Field):
+            if issubclass(_origin, models.Model):
+                kwargs['queryset'] = _origin.objects.all()
+                _origin = serializers.PrimaryKeyRelatedField
+            else:
+                _origin = FIELD_DICT[_origin]
+        self.db_field = _db_field
+        self.origin = _origin(**kwargs)
+        self.source = getattr(self.origin, 'source', '')
+
+
+def field(value_type: type, help_text: str, _db_field: bool = True, **kwargs: Any) -> _Item:
+    kwargs['help_text'] = help_text
+    return _Item(_db_field, value_type, **kwargs)
+
+
+def required(value_type: type, help_text: str, _db_field: bool = True, **kwargs: Any) -> _Item:
+    kwargs['required'] = True
+    return field(value_type, help_text, _db_field, **kwargs)

--- a/dev_up/settings.py
+++ b/dev_up/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     'allauth.socialaccount',
     'allauth.socialaccount.providers.github',
     'allauth.socialaccount.providers.google',
+    'tests',
 ]
 
 SITE_ID = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--index-url https://pypi.org/simple/
 django==3.0.3
 flake8
 isort
@@ -10,6 +11,6 @@ pytest-django==3.8.0
 djangorestframework==3.11.0
 djangorestframework-stubs==1.1.0
 drf-yasg==1.17.1
-psycopg2==2.8.4
+psycopg2-binary==2.8.4
 model-bakery==1.1.0
 django-allauth==0.41.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple/
 django==3.0.3
 flake8
 isort

--- a/tests/common/decorators/test_serializers.py
+++ b/tests/common/decorators/test_serializers.py
@@ -1,0 +1,58 @@
+import pytest
+from common.decorators.serializers import serializer, filtered_serializer, required, field, Date, \
+    model_serializer
+from rest_framework import serializers
+
+from tests.models import TestModel
+
+
+@serializer(TestModel, {'test': 1})
+class TestSerializer:
+    test_str = required(str, 'test_str')
+    test_date = field(Date, 'test_date')
+    test_no_db = field(int, 'test_no_db', False)
+
+
+@filtered_serializer(TestSerializer, ['test_str'])
+class TestFilteredSerializer:
+    test_int = required(int, 'test_int')
+
+
+@model_serializer(TestModel, {'test': 1}, ['test_str'])
+class TestModelSerializer:
+    test_no_db = field(int, 'test_no_db', False)
+
+
+@pytest.mark.django
+def test_serializer():
+    fields = TestSerializer._declared_fields
+    assert isinstance(fields['test_str'], serializers.CharField)
+    assert isinstance(fields['test_date'], serializers.DateField)
+    assert isinstance(fields['test_no_db'], serializers.IntegerField)
+    assert hasattr(TestSerializer, 'Meta')
+    assert set(TestSerializer.Meta.fields) == {'test_str', 'test_date'}
+    assert TestSerializer.Meta.model == TestModel
+    assert TestSerializer.Meta.test == 1
+
+
+@pytest.mark.django
+def test_filtered_serializer():
+    fields = TestFilteredSerializer._declared_fields
+    assert isinstance(fields['test_int'], serializers.IntegerField)
+    assert hasattr(TestFilteredSerializer, 'Meta')
+    assert isinstance(fields['test_str'], serializers.CharField)
+    assert fields.get('test_date', None) is None
+    assert TestFilteredSerializer.Meta.model == TestModel
+    assert set(TestFilteredSerializer.Meta.fields) == {'test_int', 'test_str'}
+
+
+@pytest.mark.django
+def test_model_serializer():
+    fields = TestModelSerializer._declared_fields
+    assert fields.get('test_int', None) is None
+    assert fields.get('test_date', None) is None
+    assert isinstance(fields['test_no_db'], serializers.IntegerField)
+    assert hasattr(TestModelSerializer, 'Meta')
+    assert TestModelSerializer.Meta.fields == tuple(['test_str'])
+    assert TestModelSerializer.Meta.model == TestModel
+    assert TestModelSerializer.Meta.test == 1

--- a/tests/common/decorators/test_serializers.py
+++ b/tests/common/decorators/test_serializers.py
@@ -1,8 +1,8 @@
 import pytest
-from common.decorators.serializers import serializer, filtered_serializer, required, field, Date, \
-    model_serializer
 from rest_framework import serializers
 
+from common.decorators.serializers import (Date, field, filtered_serializer, model_serializer,
+                                           required, serializer)
 from tests.models import TestModel
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,7 @@
+from django.db import models
+
+
+class TestModel(models.Model):
+    test_str = models.CharField(max_length=50)
+    test_int = models.IntegerField()
+    test_date = models.DateField()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,2 +1,0 @@
-def test_pass():
-    pass


### PR DESCRIPTION
사용예제
```python

class TestModel(models.Model):
    test_str = models.CharField(max_length=50)
    test_int = models.IntegerField()
    test_date = models.DateField()
    test_model = models.ForeignKey('OtherModel')



@serializer(TestModel, {'test': 1})
class TestSerializer:
    # test_str = serializers.CharField(required=True, help_text='help_str')
    test_str = required(str, 'help_str') 
    # test_date = serializers.DateField(help_text='help_date')
    test_date = field(Date, 'help_date')
    # test_model = serializers.PrimaryKeyRelatedField(help_text='help_date')
    test_model = field(OtherModel, 'help_model') 
    # test_no_db = serializers.IntegerField(help_text='help_no_db')
    test_no_db = field(int, 'help_no_db', False) 

    """ below Meta class will be automatically generated.
    class Meta:
          test = 1
          # test_no_db is not included because the third argument is `False`
          fields = ('test_str', 'test_date', 'test_model')
    """


@filtered_serializer(TestSerializer, ['test_str'])
class TestFilteredSerializer:
    test_int = required(int, 'help_int')

    """ below Meta class will be automatically generated.
    class Meta:
          test = 1
          # test_no_db is not included because the third argument is `False`
          fields = ('test_str', 'test_int')
    """

@model_serializer(TestModel, {'test': 1}, None)
class TestModelSerializer:
    # serializers.IntegerField(required=True, help_text='help_int', source='test_int')
    testInt = required(int, 'help_int', source='test_int') 

    """ below Meta class will be automatically generated.
    class Meta:
          test = 1
          # test_int is automatically replaced with testInt
          fields = ('test_str', 'testInt', 'test_date', 'test_model')
    """
```