### PR TITLE
Feature/post like

### DIFF
--- a/post/admin.py
+++ b/post/admin.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
 
-from post.models import Category, Comment, Post, Tag
+from post.models import Category, Comment, Like, Post, Tag
 
 # Register your models here.
 admin.site.register(Category)
 admin.site.register(Post)
 admin.site.register(Comment)
 admin.site.register(Tag)
+admin.site.register(Like)

--- a/post/api/like.py
+++ b/post/api/like.py
@@ -1,0 +1,60 @@
+from django.db import transaction
+from django.db.utils import IntegrityError
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import status, viewsets
+from rest_framework.exceptions import NotFound, ParseError, ValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from common.responses import (APPLY_201_CREATED, APPLY_204_DELETED, APPLY_400_PARAMETER_ERROR,
+                              APPLY_404_NOT_FOUND)
+from post.models import Like
+from post.serializers.like import LikeCreateSerializer
+
+
+class LikeAPI(viewsets.ViewSet):
+
+    @transaction.atomic
+    @swagger_auto_schema(query_serializer=LikeCreateSerializer,
+                         responses={200: APPLY_201_CREATED.as_md(),
+                                    400: APPLY_400_PARAMETER_ERROR.as_md()})
+    def create(self, request: Request) -> Response:
+        like_data = {**request.data}
+        serializer = LikeCreateSerializer(data=like_data)
+
+        if serializer.is_valid():
+            try:
+                serializer.save()
+                return Response(data={'detail': 'Successfully created.'},
+                                status=status.HTTP_201_CREATED)
+            except IntegrityError:
+                raise ValidationError(detail='Only one like for a post is allowed per user')
+
+        raise ValidationError(detail=serializer.errors)
+
+    @swagger_auto_schema(responses={204: APPLY_204_DELETED.as_md(),
+                                    400: APPLY_400_PARAMETER_ERROR.as_md(),
+                                    404: APPLY_404_NOT_FOUND.as_md()})
+    def destroy(self, request: Request) -> Response:
+        """
+        Make the comment disabled.
+
+        A specific comment ID must be required by uri resources.
+        """
+        try:
+            if not isinstance(request.data['user'], int):
+                raise ParseError(detail='User ID must be integer.')
+            elif not isinstance(request.data['post'], int):
+                raise ParseError(detail='Post ID must be integer.')
+        except KeyError:
+            raise ParseError(detail='User ID or Post ID is required.')
+
+        user, post = request.data['user'], request.data['post']
+        like = Like.objects.filter(user=user, post=post)
+
+        if like.exists():
+            like.delete()
+        else:
+            raise NotFound(detail='Related post or user does not exist.')
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/post/models.py
+++ b/post/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models.constraints import UniqueConstraint
 
 from user.models import User
 
@@ -65,3 +66,14 @@ class Tag(models.Model):
 
     def __str__(self) -> str:
         return f'Tag(title="{self.title}")'
+
+
+class Like(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    post = models.ForeignKey(Post, on_delete=models.CASCADE)
+
+    class Meta:
+        constraints = [UniqueConstraint(
+            fields=['user', 'post'],
+            name='UQ_like_user_post',
+        )]

--- a/post/routers.py
+++ b/post/routers.py
@@ -18,6 +18,7 @@ from django.urls import path, re_path
 
 from post.api.category import CategoryAPI
 from post.api.comment import CommentAPI
+from post.api.like import LikeAPI
 from post.api.post import PostAPI
 from post.api.tag import TagAPI
 
@@ -34,6 +35,10 @@ urlpatterns = [
     path('/<int:post_id>', PostAPI.as_view({
         'get': 'retrieve',
         'patch': 'partial_update',
+        'delete': 'destroy',
+    })),
+    path('/likes', LikeAPI.as_view({
+        'post': 'create',
         'delete': 'destroy',
     })),
     re_path(r'^$', PostAPI.as_view({

--- a/post/serializers/like.py
+++ b/post/serializers/like.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+
+from post.models import Like
+
+
+class LikeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Like
+        depth = 1
+        fields = ('user', 'post')
+
+
+class LikeCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Like
+        fields = ('user', 'post')

--- a/tests/post/test_like.py
+++ b/tests/post/test_like.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+@pytest.fixture
+def user_post_data(users, posts):
+    return {'user': users[0].id, 'post': posts[0].id}
+
+
+class TestLike:
+    pytestmark = pytest.mark.django_db
+
+    def _like_a_post(self, api_client, data):
+        response = api_client.post('/posts/likes', data=data, format='json')
+        liked_post = api_client.get(f'/posts/{data["post"]}')
+        return [response, liked_post]
+
+    def test_create_like(self, api_client, user_post_data):
+        response, liked_post = self._like_a_post(api_client, user_post_data)
+        assert response.status_code == 201
+        assert liked_post.data['likes'] == 1
+
+        # Prevent requesting like to the same post.
+        response, liked_post = self._like_a_post(api_client, user_post_data)
+        assert response.status_code == 400
+        assert liked_post.data['likes'] == 1
+
+    def test_dislike(self, api_client, user_post_data):
+        response, liked_post = self._like_a_post(api_client, user_post_data)
+        response = api_client.delete('/posts/likes', data=user_post_data, format='json')
+        disliked_post = api_client.get('/posts/1')
+        assert response.status_code == 204
+        assert liked_post.data['likes'] != disliked_post.data['likes']
+
+        # Prevent requesting dislike to the same post.
+        response = api_client.delete('/posts/likes', data=user_post_data, format='json')
+        assert response.status_code == 404


### PR DESCRIPTION
Post에 Like 기능을 추가했습니다.

User 쪽에서 Like를 사용하고 싶으면 간단하게 Serializer에 추가만 해주는 것으로 간편하게
관련된 Like 정보를 뽑을 수 있어서 편리하게 구현할 수 있습니다.
(현재 저희 프로젝트의 경우 예를 들면, UserDetailsSerializer에 단 네 줄 정도만 추가하면 like 정보도 뽑아올 수 있습니다.)

그리고 Post 쪽에서는 like의 갯수만 출력하면 되지만, User쪽에서는 어떻게 사용할지 몰라서
LikeSerializer와 LikeCreateSerializer를 분리 했습니다. (depth 옵션 때문)

drf 자체에서는 __init__()을 호출할 때 Meta 클래스에 접근하여 필드를 조정하는 것에 문제가 없지만,
일전에 feature/post-swagger와 관련되서도 언급했듯이, drf_yasg가 serializer를 singleton으로 사용하여
하나의 Serializer만으로 통합하여 사용하면 Serializer 객체에서 필드를 바꿔서 출력하는 것에 제대로 대응을 하지 못해서
어쩔 수 없이 여기서도 LikeSerializer와 LikeCreateSerializer로 분리했습니다.

이와 관련되어서는 계속해서 docs를 읽어보고 검색을 해보고는 있지만 swagger 관련 라이브러리를 바꾸지 않는 이상 해결방법이 없어보입니다. (현재 drf_yasg의 업데이트가 뜸해지고 있는 것 같습니다.)