### PR TITLE
Fix test errors related with authorization

### DIFF
--- a/common/jwt.py
+++ b/common/jwt.py
@@ -3,7 +3,7 @@ from rest_framework_jwt.settings import api_settings
 from user.models import User
 
 
-def get_jwt_token_of(user: User) -> str:
+def get_jwt_of(user: User) -> str:
     jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
     jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
 

--- a/post/api/category.py
+++ b/post/api/category.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -7,6 +8,8 @@ from post.serializers import CategorySerializer
 
 
 class CategoryAPI(viewsets.ViewSet):
+    permission_classes = [AllowAny]
+
     def list(self, request: Request) -> Response:
         """
         Get the list of categories.

--- a/post/api/post.py
+++ b/post/api/post.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Type, Union
+from typing import List, Optional
 
 from django.core.paginator import Paginator
 from django.db import transaction
@@ -17,17 +17,10 @@ from post.serializers import (PostCreateSerializer, PostDetailSerializer, PostPa
 
 
 class PostAPI(viewsets.ViewSet):
-    def __init__(self) -> None:
-        self.action = None
-        super().__init__()
+    action: Optional[str] = None
 
     def get_permissions(self) -> List[BasePermission]:
-        permission_classes: List[Union[Type[AllowAny], Type[IsAuthenticated]]] = list()
-
-        if self.action in ['list', 'retrieve']:
-            permission_classes = [AllowAny]
-        else:
-            permission_classes = [IsAuthenticated]
+        permission_classes = [AllowAny if self.action in ['list', 'retrieve'] else IsAuthenticated]
         return [permission() for permission in permission_classes]
 
     def _tag_filter(self, posts: 'QuerySet[Post]', params: QueryDict) -> 'QuerySet[Post]':

--- a/post/api/tag.py
+++ b/post/api/tag.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -7,6 +8,8 @@ from post.serializers import TagSerializer
 
 
 class TagAPI(viewsets.ViewSet):
+    permission_classes = [AllowAny]
+
     def list(self, request: Request) -> Response:
         """
         Get the list of tags.

--- a/tests/post/conftest.py
+++ b/tests/post/conftest.py
@@ -4,6 +4,7 @@ from model_bakery import baker
 import pytest
 from rest_framework.test import APIClient
 
+from common.jwt import get_jwt_of
 from post.models import Category, Comment, Post, Tag
 from user.models import User
 
@@ -41,3 +42,8 @@ def many_posts() -> List[Post]:
 @pytest.fixture
 def comments() -> List[Comment]:
     return baker.make(Comment, _quantity=3)
+
+
+@pytest.fixture
+def token(users):
+    return f'JWT {get_jwt_of(users[0])}'

--- a/tests/post/jwt_token.py
+++ b/tests/post/jwt_token.py
@@ -1,0 +1,12 @@
+from rest_framework_jwt.settings import api_settings
+
+from user.models import User
+
+
+def get_jwt_token_of(user: User) -> str:
+    jwt_payload_handler = api_settings.JWT_PAYLOAD_HANDLER
+    jwt_encode_handler = api_settings.JWT_ENCODE_HANDLER
+
+    payload = jwt_payload_handler(user)
+    token = jwt_encode_handler(payload)
+    return token

--- a/tests/post/test_category.py
+++ b/tests/post/test_category.py
@@ -5,6 +5,6 @@ class TestCategory:
     pytestmark = pytest.mark.django_db
 
     def test_list_categories(self, api_client, categories):
-        response = api_client.get('/posts/categories')
+        response = api_client.get('/posts/categories', secure=True)
         assert response.status_code == 200
         assert len(response.data) > 1

--- a/tests/post/test_comment.py
+++ b/tests/post/test_comment.py
@@ -1,28 +1,39 @@
 import pytest
 
 from post.models import Comment
+from tests.post.jwt_token import get_jwt_token_of
 
 
 class TestComment:
     pytestmark = pytest.mark.django_db
 
     def test_create_comment(self, api_client, users, posts):
+        token = f'JWT {get_jwt_token_of(users[0])}'
         response = api_client.post('/posts/comments', data={
             'content': 'creating',
             'post': 1,
             'author': 1,
-        }, format='json', secure=True)
+        }, HTTP_AUTHORIZATION=token, format='json', secure=True)
         assert response.status_code == 201
 
         # Create a comment without a post ID
         response = api_client.post(
-            '/posts/comments', data={'content': 'no_post_id'}, format='json', secure=True)
+            '/posts/comments',
+            data={'content': 'no_post_id'},
+            HTTP_AUTHORIZATION=token,
+            format='json',
+            secure=True)
         assert response.status_code == 400
 
-    def test_update_comment(self, api_client, comments):
+    def test_update_comment(self, api_client, comments, users):
+        token = f'JWT {get_jwt_token_of(users[0])}'
         content_before_update = Comment.objects.get(id=1).content
         response = api_client.put(
-            '/posts/comments/1', data={'content': 'after'}, format='json', secure=True)
+            '/posts/comments/1',
+            data={'content': 'after'},
+            HTTP_AUTHORIZATION=token,
+            format='json',
+            secure=True)
 
         updated_comment = Comment.objects.get(id=1)
         assert response.status_code == 200
@@ -31,11 +42,12 @@ class TestComment:
         assert updated_comment.content != content_before_update
 
         # Update the comment without any data.
-        response = api_client.put('/posts/comments/1', secure=True)
+        response = api_client.put('/posts/comments/1', HTTP_AUTHORIZATION=token, secure=True)
         assert response.status_code == 400
 
-    def test_delete_comment(self, api_client, comments):
-        response = api_client.delete('/posts/comments/1', secure=True)
+    def test_delete_comment(self, api_client, comments, users):
+        token = f'JWT {get_jwt_token_of(users[0])}'
+        response = api_client.delete('/posts/comments/1', HTTP_AUTHORIZATION=token, secure=True)
         comment = Comment.objects.get(id=1)
 
         assert response.status_code == 204

--- a/tests/post/test_comment.py
+++ b/tests/post/test_comment.py
@@ -23,7 +23,7 @@ class TestComment:
             secure=True)
         assert response.status_code == 400
 
-    def test_update_comment(self, api_client, comments, users, token):
+    def test_update_comment(self, api_client, comments, token):
         content_before_update = Comment.objects.get(id=1).content
         response = api_client.put(
             '/posts/comments/1',
@@ -42,7 +42,7 @@ class TestComment:
         response = api_client.put('/posts/comments/1', HTTP_AUTHORIZATION=token, secure=True)
         assert response.status_code == 400
 
-    def test_delete_comment(self, api_client, comments, users, token):
+    def test_delete_comment(self, api_client, comments, token):
         response = api_client.delete('/posts/comments/1', HTTP_AUTHORIZATION=token, secure=True)
         comment = Comment.objects.get(id=1)
 

--- a/tests/post/test_comment.py
+++ b/tests/post/test_comment.py
@@ -1,14 +1,12 @@
 import pytest
 
 from post.models import Comment
-from tests.post.jwt_token import get_jwt_token_of
 
 
 class TestComment:
     pytestmark = pytest.mark.django_db
 
-    def test_create_comment(self, api_client, users, posts):
-        token = f'JWT {get_jwt_token_of(users[0])}'
+    def test_create_comment(self, api_client, users, posts, token):
         response = api_client.post('/posts/comments', data={
             'content': 'creating',
             'post': 1,
@@ -25,8 +23,7 @@ class TestComment:
             secure=True)
         assert response.status_code == 400
 
-    def test_update_comment(self, api_client, comments, users):
-        token = f'JWT {get_jwt_token_of(users[0])}'
+    def test_update_comment(self, api_client, comments, users, token):
         content_before_update = Comment.objects.get(id=1).content
         response = api_client.put(
             '/posts/comments/1',
@@ -45,8 +42,7 @@ class TestComment:
         response = api_client.put('/posts/comments/1', HTTP_AUTHORIZATION=token, secure=True)
         assert response.status_code == 400
 
-    def test_delete_comment(self, api_client, comments, users):
-        token = f'JWT {get_jwt_token_of(users[0])}'
+    def test_delete_comment(self, api_client, comments, users, token):
         response = api_client.delete('/posts/comments/1', HTTP_AUTHORIZATION=token, secure=True)
         comment = Comment.objects.get(id=1)
 

--- a/tests/post/test_comment.py
+++ b/tests/post/test_comment.py
@@ -11,18 +11,18 @@ class TestComment:
             'content': 'creating',
             'post': 1,
             'author': 1,
-        }, format='json')
+        }, format='json', secure=True)
         assert response.status_code == 201
 
         # Create a comment without a post ID
         response = api_client.post(
-            '/posts/comments', data={'content': 'no_post_id'}, format='json')
+            '/posts/comments', data={'content': 'no_post_id'}, format='json', secure=True)
         assert response.status_code == 400
 
     def test_update_comment(self, api_client, comments):
         content_before_update = Comment.objects.get(id=1).content
         response = api_client.put(
-            '/posts/comments/1', data={'content': 'after'}, format='json')
+            '/posts/comments/1', data={'content': 'after'}, format='json', secure=True)
 
         updated_comment = Comment.objects.get(id=1)
         assert response.status_code == 200
@@ -31,11 +31,11 @@ class TestComment:
         assert updated_comment.content != content_before_update
 
         # Update the comment without any data.
-        response = api_client.put('/posts/comments/1')
+        response = api_client.put('/posts/comments/1', secure=True)
         assert response.status_code == 400
 
     def test_delete_comment(self, api_client, comments):
-        response = api_client.delete('/posts/comments/1')
+        response = api_client.delete('/posts/comments/1', secure=True)
         comment = Comment.objects.get(id=1)
 
         assert response.status_code == 204

--- a/tests/post/test_post.py
+++ b/tests/post/test_post.py
@@ -18,13 +18,13 @@ class TestPost:
             'category': 1,
             'tags': ['tag1', 'tag2'],
         }
-        response = api_client.post('/posts', data=post_data, format='json')
+        response = api_client.post('/posts', data=post_data, format='json', secure=True)
         assert response.status_code == 201
 
         # Create a post with tag titles that already exist.
         before_creating = api_client.get('/posts/tags')
 
-        response = api_client.post('/posts', data=post_data, format='json')
+        response = api_client.post('/posts', data=post_data, format='json', secure=True)
         assert response.status_code == 201
 
         after_creating = api_client.get('/posts/tags')
@@ -38,7 +38,7 @@ class TestPost:
             'timeOfDay': 1,
             'author': 1,
         }
-        response = api_client.post('/posts', data=bad_post_data, format='json')
+        response = api_client.post('/posts', data=bad_post_data, format='json', secure=True)
         assert response.status_code == 400
 
         # Cause an error of creating post after creating tags successfully
@@ -47,7 +47,7 @@ class TestPost:
 
         post_data['tags'] = ['tag3', 'tag4']
         post_data['title'] = '1'*100
-        response = api_client.post('/posts', data=post_data, format='json')
+        response = api_client.post('/posts', data=post_data, format='json', secure=True)
         assert response.status_code == 400
 
         after_transaction = api_client.get('/posts/tags')
@@ -80,7 +80,7 @@ class TestPost:
             'title': 'after',
             'tags': [tags[0].title, tags[1].title]
         }
-        response = api_client.patch('/posts/1', data=data, format='json')
+        response = api_client.patch('/posts/1', data=data, format='json', secure=True)
 
         updated_post = Post.objects.get(id=1)
         assert response.status_code == 200
@@ -98,7 +98,7 @@ class TestPost:
             'timeOfDay': 1,
             'createdDate': '2020-02-02',
         }
-        response = api_client.patch('/posts/1', data=bad_post_data, format='json')
+        response = api_client.patch('/posts/1', data=bad_post_data, format='json', secure=True)
         after_update = api_client.get('/posts/1')
         assert before_update.data['createdDate'] == after_update.data['createdDate']
 
@@ -106,18 +106,18 @@ class TestPost:
         before_update = api_client.get('/posts/1')
 
         tags = {'tags': ['tag1', 'tag2']}
-        response = api_client.patch('/posts/1', data=tags, format='json')
+        response = api_client.patch('/posts/1', data=tags, format='json', secure=True)
         assert response.status_code == 200
 
         after_update = api_client.get('/posts/1')
         assert before_update.data['tags'][0]['title'] != after_update.data['tags'][0]['title']
 
         # Update the post without any data.
-        response = api_client.patch('/posts/1')
+        response = api_client.patch('/posts/1', secure=True)
         assert response.status_code == 400
 
     def test_delete_post(self, api_client, posts):
-        response = api_client.delete('/posts/1')
+        response = api_client.delete('/posts/1', secure=True)
         after_delete = api_client.get('/posts/1')
 
         assert response.status_code == 204

--- a/tests/post/test_post.py
+++ b/tests/post/test_post.py
@@ -22,12 +22,12 @@ class TestPost:
         assert response.status_code == 201
 
         # Create a post with tag titles that already exist.
-        before_creating = api_client.get('/posts/tags')
+        before_creating = api_client.get('/posts/tags', secure=True)
 
         response = api_client.post('/posts', data=post_data, format='json', secure=True)
         assert response.status_code == 201
 
-        after_creating = api_client.get('/posts/tags')
+        after_creating = api_client.get('/posts/tags', secure=True)
         assert len(before_creating.data) == len(after_creating.data)
 
         # Create a post without a category ID and tag titles.
@@ -43,38 +43,38 @@ class TestPost:
 
         # Cause an error of creating post after creating tags successfully
         # in order to test transaction.
-        before_transaction = api_client.get('/posts/tags')
+        before_transaction = api_client.get('/posts/tags', secure=True)
 
         post_data['tags'] = ['tag3', 'tag4']
         post_data['title'] = '1'*100
         response = api_client.post('/posts', data=post_data, format='json', secure=True)
         assert response.status_code == 400
 
-        after_transaction = api_client.get('/posts/tags')
+        after_transaction = api_client.get('/posts/tags', secure=True)
         assert before_transaction.data == after_transaction.data
 
     def test_list_posts(self, api_client, many_posts):
         # Pagination
-        response = api_client.get('/posts')
+        response = api_client.get('/posts', secure=True)
         assert response.status_code == 200
         assert len(response.data) > 1
 
         # Pagination by specific number per page
-        response = api_client.get('/posts?page=1&pageSize=30')
+        response = api_client.get('/posts?page=1&pageSize=30', secure=True)
         assert response.status_code == 200
         assert len(response.data) == 30
 
     def test_detail_post(self, api_client, posts):
-        response = api_client.get('/posts/1')
+        response = api_client.get('/posts/1', secure=True)
         assert response.status_code == 200
         assert response.data['id'] == 1
 
         # Get a post that doesn't exist.
-        response = api_client.get('/posts/65535')
+        response = api_client.get('/posts/65535', secure=True)
         assert response.status_code == 404
 
     def test_update_post(self, api_client, posts, tags):
-        before_update = api_client.get('/posts/1')
+        before_update = api_client.get('/posts/1', secure=True)
 
         data = {
             'title': 'after',
@@ -89,7 +89,7 @@ class TestPost:
         assert before_update.data['title'] != 'after'
 
         # Prevent updating the created date of the post.
-        before_update = api_client.get('/posts/1')
+        before_update = api_client.get('/posts/1', secure=True)
 
         bad_post_data = {
             'title': 'test_title',
@@ -99,17 +99,17 @@ class TestPost:
             'createdDate': '2020-02-02',
         }
         response = api_client.patch('/posts/1', data=bad_post_data, format='json', secure=True)
-        after_update = api_client.get('/posts/1')
+        after_update = api_client.get('/posts/1', secure=True)
         assert before_update.data['createdDate'] == after_update.data['createdDate']
 
         # Update the tags of the post.
-        before_update = api_client.get('/posts/1')
+        before_update = api_client.get('/posts/1', secure=True)
 
         tags = {'tags': ['tag1', 'tag2']}
         response = api_client.patch('/posts/1', data=tags, format='json', secure=True)
         assert response.status_code == 200
 
-        after_update = api_client.get('/posts/1')
+        after_update = api_client.get('/posts/1', secure=True)
         assert before_update.data['tags'][0]['title'] != after_update.data['tags'][0]['title']
 
         # Update the post without any data.
@@ -118,7 +118,7 @@ class TestPost:
 
     def test_delete_post(self, api_client, posts):
         response = api_client.delete('/posts/1', secure=True)
-        after_delete = api_client.get('/posts/1')
+        after_delete = api_client.get('/posts/1', secure=True)
 
         assert response.status_code == 204
         assert after_delete.status_code == 404

--- a/tests/post/test_post.py
+++ b/tests/post/test_post.py
@@ -1,12 +1,14 @@
 import pytest
 
 from post.models import Post
+from tests.post.jwt_token import get_jwt_token_of
 
 
 class TestPost:
     pytestmark = pytest.mark.django_db
 
     def test_create_post(self, api_client, users, categories):
+        token = f'JWT {get_jwt_token_of(users[0])}'
         post_data = {
             'title': 'test_title',
             'content': 'test_content',
@@ -18,13 +20,15 @@ class TestPost:
             'category': 1,
             'tags': ['tag1', 'tag2'],
         }
-        response = api_client.post('/posts', data=post_data, format='json', secure=True)
+        response = api_client.post('/posts', data=post_data,
+                                   HTTP_AUTHORIZATION=token, format='json', secure=True)
         assert response.status_code == 201
 
         # Create a post with tag titles that already exist.
         before_creating = api_client.get('/posts/tags', secure=True)
 
-        response = api_client.post('/posts', data=post_data, format='json', secure=True)
+        response = api_client.post('/posts', data=post_data,
+                                   HTTP_AUTHORIZATION=token, format='json', secure=True)
         assert response.status_code == 201
 
         after_creating = api_client.get('/posts/tags', secure=True)
@@ -38,7 +42,8 @@ class TestPost:
             'timeOfDay': 1,
             'author': 1,
         }
-        response = api_client.post('/posts', data=bad_post_data, format='json', secure=True)
+        response = api_client.post('/posts', data=bad_post_data,
+                                   HTTP_AUTHORIZATION=token, format='json', secure=True)
         assert response.status_code == 400
 
         # Cause an error of creating post after creating tags successfully
@@ -47,13 +52,14 @@ class TestPost:
 
         post_data['tags'] = ['tag3', 'tag4']
         post_data['title'] = '1'*100
-        response = api_client.post('/posts', data=post_data, format='json', secure=True)
+        response = api_client.post('/posts', data=post_data,
+                                   HTTP_AUTHORIZATION=token, format='json', secure=True)
         assert response.status_code == 400
 
         after_transaction = api_client.get('/posts/tags', secure=True)
         assert before_transaction.data == after_transaction.data
 
-    def test_list_posts(self, api_client, many_posts):
+    def test_list_posts(self, api_client, many_posts, users):
         # Pagination
         response = api_client.get('/posts', secure=True)
         assert response.status_code == 200
@@ -64,7 +70,7 @@ class TestPost:
         assert response.status_code == 200
         assert len(response.data) == 30
 
-    def test_detail_post(self, api_client, posts):
+    def test_detail_post(self, api_client, posts, users):
         response = api_client.get('/posts/1', secure=True)
         assert response.status_code == 200
         assert response.data['id'] == 1
@@ -73,14 +79,16 @@ class TestPost:
         response = api_client.get('/posts/65535', secure=True)
         assert response.status_code == 404
 
-    def test_update_post(self, api_client, posts, tags):
+    def test_update_post(self, api_client, posts, tags, users):
+        token = f'JWT {get_jwt_token_of(users[0])}'
         before_update = api_client.get('/posts/1', secure=True)
 
         data = {
             'title': 'after',
             'tags': [tags[0].title, tags[1].title]
         }
-        response = api_client.patch('/posts/1', data=data, format='json', secure=True)
+        response = api_client.patch('/posts/1', data=data,
+                                    HTTP_AUTHORIZATION=token, format='json', secure=True)
 
         updated_post = Post.objects.get(id=1)
         assert response.status_code == 200
@@ -98,7 +106,8 @@ class TestPost:
             'timeOfDay': 1,
             'createdDate': '2020-02-02',
         }
-        response = api_client.patch('/posts/1', data=bad_post_data, format='json', secure=True)
+        response = api_client.patch('/posts/1', data=bad_post_data,
+                                    HTTP_AUTHORIZATION=token, format='json', secure=True)
         after_update = api_client.get('/posts/1', secure=True)
         assert before_update.data['createdDate'] == after_update.data['createdDate']
 
@@ -106,18 +115,20 @@ class TestPost:
         before_update = api_client.get('/posts/1', secure=True)
 
         tags = {'tags': ['tag1', 'tag2']}
-        response = api_client.patch('/posts/1', data=tags, format='json', secure=True)
+        response = api_client.patch('/posts/1', data=tags,
+                                    HTTP_AUTHORIZATION=token, format='json', secure=True)
         assert response.status_code == 200
 
         after_update = api_client.get('/posts/1', secure=True)
         assert before_update.data['tags'][0]['title'] != after_update.data['tags'][0]['title']
 
         # Update the post without any data.
-        response = api_client.patch('/posts/1', secure=True)
+        response = api_client.patch('/posts/1', HTTP_AUTHORIZATION=token, secure=True)
         assert response.status_code == 400
 
-    def test_delete_post(self, api_client, posts):
-        response = api_client.delete('/posts/1', secure=True)
+    def test_delete_post(self, api_client, posts, users):
+        token = f'JWT {get_jwt_token_of(users[0])}'
+        response = api_client.delete('/posts/1', HTTP_AUTHORIZATION=token, secure=True)
         after_delete = api_client.get('/posts/1', secure=True)
 
         assert response.status_code == 204

--- a/tests/post/test_post.py
+++ b/tests/post/test_post.py
@@ -1,14 +1,12 @@
 import pytest
 
 from post.models import Post
-from tests.post.jwt_token import get_jwt_token_of
 
 
 class TestPost:
     pytestmark = pytest.mark.django_db
 
-    def test_create_post(self, api_client, users, categories):
-        token = f'JWT {get_jwt_token_of(users[0])}'
+    def test_create_post(self, api_client, users, categories, token):
         post_data = {
             'title': 'test_title',
             'content': 'test_content',
@@ -79,8 +77,7 @@ class TestPost:
         response = api_client.get('/posts/65535', secure=True)
         assert response.status_code == 404
 
-    def test_update_post(self, api_client, posts, tags, users):
-        token = f'JWT {get_jwt_token_of(users[0])}'
+    def test_update_post(self, api_client, posts, tags, users, token):
         before_update = api_client.get('/posts/1', secure=True)
 
         data = {
@@ -126,8 +123,7 @@ class TestPost:
         response = api_client.patch('/posts/1', HTTP_AUTHORIZATION=token, secure=True)
         assert response.status_code == 400
 
-    def test_delete_post(self, api_client, posts, users):
-        token = f'JWT {get_jwt_token_of(users[0])}'
+    def test_delete_post(self, api_client, posts, users, token):
         response = api_client.delete('/posts/1', HTTP_AUTHORIZATION=token, secure=True)
         after_delete = api_client.get('/posts/1', secure=True)
 

--- a/tests/post/test_post.py
+++ b/tests/post/test_post.py
@@ -57,7 +57,7 @@ class TestPost:
         after_transaction = api_client.get('/posts/tags', secure=True)
         assert before_transaction.data == after_transaction.data
 
-    def test_list_posts(self, api_client, many_posts, users):
+    def test_list_posts(self, api_client, many_posts):
         # Pagination
         response = api_client.get('/posts', secure=True)
         assert response.status_code == 200
@@ -68,7 +68,7 @@ class TestPost:
         assert response.status_code == 200
         assert len(response.data) == 30
 
-    def test_detail_post(self, api_client, posts, users):
+    def test_detail_post(self, api_client, posts):
         response = api_client.get('/posts/1', secure=True)
         assert response.status_code == 200
         assert response.data['id'] == 1
@@ -77,7 +77,7 @@ class TestPost:
         response = api_client.get('/posts/65535', secure=True)
         assert response.status_code == 404
 
-    def test_update_post(self, api_client, posts, tags, users, token):
+    def test_update_post(self, api_client, posts, tags, token):
         before_update = api_client.get('/posts/1', secure=True)
 
         data = {
@@ -123,7 +123,7 @@ class TestPost:
         response = api_client.patch('/posts/1', HTTP_AUTHORIZATION=token, secure=True)
         assert response.status_code == 400
 
-    def test_delete_post(self, api_client, posts, users, token):
+    def test_delete_post(self, api_client, posts, token):
         response = api_client.delete('/posts/1', HTTP_AUTHORIZATION=token, secure=True)
         after_delete = api_client.get('/posts/1', secure=True)
 

--- a/tests/post/test_post_filtering.py
+++ b/tests/post/test_post_filtering.py
@@ -1,5 +1,5 @@
-from model_bakery.recipe import Recipe
 import pytest
+from model_bakery.recipe import Recipe
 
 from post.models import Post
 
@@ -63,7 +63,7 @@ class TestPostFiltering:
 
     def test_post_on_category_filtering(self, api_client, posts, categories):
         category_title = categories[0].title
-        response = api_client.get(f'/posts?category={category_title}')
+        response = api_client.get(f'/posts?category={category_title}', secure=True)
         assert response.status_code == 200
         assert len(response.data) == 2
 
@@ -73,7 +73,7 @@ class TestPostFiltering:
 
     def test_post_on_tag_filtering(self, api_client, posts, tags):
         tag_title = tags[1].title
-        response = api_client.get(f'/posts?tags={tag_title}')
+        response = api_client.get(f'/posts?tags={tag_title}', secure=True)
         assert response.status_code == 200
         assert len(response.data) == 2
 
@@ -82,7 +82,7 @@ class TestPostFiltering:
 
         # Filter the posts by more than one tag.
         tag_title1, tag_title2 = tags[0].title, tags[1].title
-        response = api_client.get(f'/posts?tags={tag_title1},{tag_title2}')
+        response = api_client.get(f'/posts?tags={tag_title1},{tag_title2}', secure=True)
         assert response.status_code == 200
         assert len(response.data) == 2
 
@@ -90,12 +90,13 @@ class TestPostFiltering:
         count_tags_of_multiple(response, tag_title1, tag_title2)
 
         # This type of tag filtering is not supported.
-        response = api_client.get(f'/posts?tags={tag_title1}&tags={tag_title2}')
+        response = api_client.get(f'/posts?tags={tag_title1}&tags={tag_title2}', secure=True)
         assert response.status_code == 400
 
     def test_post_on_category_tag_filtering(self, api_client, posts, categories, tags):
         category_title, tag_title = categories[0].title, tags[1].title
-        response = api_client.get(f'/posts?category={category_title}&tags={tag_title}')
+        response = api_client.get(
+            f'/posts?category={category_title}&tags={tag_title}', secure=True)
         assert response.status_code == 200
         assert len(response.data) == 1
 
@@ -107,7 +108,7 @@ class TestPostFiltering:
 
     def test_post_on_date_filtering(self, api_client, posts):
         start_date, end_date = '2020-01-01', '2020-02-02'
-        response = api_client.get(f'/posts?startDate={start_date}&endDate={end_date}')
+        response = api_client.get(f'/posts?startDate={start_date}&endDate={end_date}', secure=True)
         assert response.status_code == 200
         assert len(response.data) == 2
 
@@ -116,7 +117,7 @@ class TestPostFiltering:
 
     def test_post_on_time_of_day_filtering(self, api_client, posts):
         time_of_day = TIME_OF_DAY['AFTERNOON']
-        response = api_client.get(f'/posts?timeOfDay={time_of_day}')
+        response = api_client.get(f'/posts?timeOfDay={time_of_day}', secure=True)
         assert response.status_code == 200
         assert len(response.data) == 2
 
@@ -125,7 +126,7 @@ class TestPostFiltering:
 
     def test_post_on_location_filtering(self, api_client, posts):
         location = 'location'
-        response = api_client.get(f'/posts?location={location}')
+        response = api_client.get(f'/posts?location={location}', secure=True)
         assert response.status_code == 200
         assert len(response.data) == 2
 

--- a/tests/post/test_post_filtering.py
+++ b/tests/post/test_post_filtering.py
@@ -1,5 +1,5 @@
-import pytest
 from model_bakery.recipe import Recipe
+import pytest
 
 from post.models import Post
 

--- a/tests/post/test_tag.py
+++ b/tests/post/test_tag.py
@@ -5,6 +5,6 @@ class TestTag:
     pytestmark = pytest.mark.django_db
 
     def test_list_tags(self, api_client, tags):
-        response = api_client.get('/posts/tags')
+        response = api_client.get('/posts/tags', secure=True)
         assert response.status_code == 200
         assert len(response.data) > 1


### PR DESCRIPTION
JWT를 적용하고 난 뒤 모든 API 접근에 권한이 필요해져서
테스트 코드에서 401 에러가 나는 부분을 우선적으로 수정했습니다.
(JWT 토큰을 헤더에 넣어서 요청하도록 변경)

추가: HTTPS로 돌아가는 서버 환경에서도 테스트코드에 에러가 나지 않도록 secure=True 옵션 추가했습니다.